### PR TITLE
BSON registers Id<TBehavior> for assemblies

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -9,10 +9,10 @@ jobs:
  
     steps:
     - uses: actions/checkout@v1
-    - name: Setup .NET Core
+    - name: Setup .NET 5.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.100
+        dotnet-version: 5.0.100
     - name: Build with dotnet
       run: dotnet build --configuration Release
     - name: Run unit tests

--- a/props/package.props
+++ b/props/package.props
@@ -18,9 +18,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+    <PackageReference Include="StyleCop" Version="6.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <NoWarn>NU1701</NoWarn>
     </PackageReference>
   </ItemGroup>
 

--- a/shared/ConventionBasedSerializer.Initialize.cs
+++ b/shared/ConventionBasedSerializer.Initialize.cs
@@ -12,7 +12,7 @@ namespace Qowaiv.Internals
         private static readonly Type[] NodeTypes = new[] { typeof(string), typeof(double), typeof(long), typeof(bool) };
 #pragma warning restore S2743 // Static fields should not be used in generic types
 
-        private Type SvoType { get; } = TypeHelper.GetNotNullableType(typeof(TSvo));
+        private Type SvoType { get; } = TypeHelper.NotNullable(typeof(TSvo));
 
         private void Initialize()
         {

--- a/shared/Guard.cs
+++ b/shared/Guard.cs
@@ -1,7 +1,7 @@
 ﻿//-----------------------------------------------------------------------
 // <copyright>
 //    Copyright (c) Corniel Nobel. All rights reserved.
-//    See: https://github.com/Corniel/Grenadiers/blob/master/README.md
+//    See: https://github.com/Corniel/Grenadiers/blob/master/LICENSE.md
 // </copyright>
 //-----------------------------------------------------------------------
 
@@ -9,6 +9,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 
@@ -20,9 +21,10 @@ namespace Qowaiv
     /// * Change the namespace to maximum shared namespace amongst the using projects
     /// * Keep it internal and use [assembly: InternalsVisibleTo] to open up access
     /// * Add specific Guard methods if you software needs them.
-    /// * Keep the checks cheep so that you also can run them in production code.
+    /// * Keep the checks cheap so that you also can run them in production code.
     /// </remarks>
-    internal static class Guard
+    [ExcludeFromCodeCoverage]
+    internal static partial class Guard
     {
         /// <summary>Guards the parameter if not null, otherwise throws an argument (null) exception.</summary>
         /// <typeparam name="T">The type to guard; cannot be a structure.</typeparam>
@@ -32,16 +34,9 @@ namespace Qowaiv
         /// The guarded parameter.
         /// </returns>
         [DebuggerStepThrough]
-        public static T NotNull<T>([ValidatedNotNull]T parameter, string paramName)
+        public static T NotNull<T>([ValidatedNotNull] T parameter, string paramName)
             where T : class
-        {
-            if (parameter is null)
-            {
-                throw new ArgumentNullException(paramName);
-            }
-
-            return parameter;
-        }
+            => parameter ?? throw new ArgumentNullException(paramName);
 
         /// <summary>Throws an ArgumentException if the nullable parameter has no value, otherwise the parameter value is passed.</summary>
         /// <typeparam name="T">The type to guard; must be a structure.</typeparam>
@@ -53,14 +48,7 @@ namespace Qowaiv
         [DebuggerStepThrough]
         public static T HasValue<T>(T? parameter, string paramName)
             where T : struct
-        {
-            if (!parameter.HasValue)
-            {
-                throw new ArgumentException(Messages.ArgumentException_NullableMustHaveValue, paramName);
-            }
-
-            return parameter.Value;
-        }
+            => parameter ?? throw new ArgumentException(Messages.ArgumentException_NullableMustHaveValue, paramName);
 
         /// <summary>
         /// Throws an ArgumentException if the nullable parameter has no value or the default value,
@@ -74,8 +62,7 @@ namespace Qowaiv
         /// </returns>
         [DebuggerStepThrough]
         public static T NotDefault<T>(T? parameter, string paramName)
-            where T : struct =>
-            NotDefault(HasValue(parameter, paramName), paramName);
+            where T : struct => NotDefault(HasValue(parameter, paramName), paramName);
 
         /// <summary>Throws an ArgumentException if the parameter has the default value, otherwise the parameter value is passed.</summary>
         /// <typeparam name="T">The type to guard; must be a structure.</typeparam>
@@ -87,14 +74,9 @@ namespace Qowaiv
         [DebuggerStepThrough]
         public static T NotDefault<T>(T parameter, string paramName)
             where T : struct
-        {
-            if (parameter.Equals(default(T)))
-            {
-                throw new ArgumentException(Messages.ArgumentException_IsDefaultValue, paramName);
-            }
-
-            return parameter;
-        }
+            => parameter.Equals(default(T))
+            ? throw new ArgumentException(Messages.ArgumentException_IsDefaultValue, paramName)
+            : parameter;
 
         /// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if the parameter is not in the collection, otherwise the parameter is passed.</summary>
         /// <typeparam name="T">The type to guard; must be a structure.</typeparam>
@@ -107,15 +89,9 @@ namespace Qowaiv
         [DebuggerStepThrough]
         public static T In<T>(T parameter, string paramName, params T[] allowedRange)
             where T : struct
-        {
-            if (!allowedRange.Contains(parameter))
-            {
-                var allowed = string.Join(", ", allowedRange);
-                throw new ArgumentOutOfRangeException(paramName, string.Format(CultureInfo.CurrentCulture, Messages.ArgumentOutOfRangeException_NotInCollection, allowed));
-            }
-
-            return parameter;
-        }
+            => allowedRange.Contains(parameter)
+            ? parameter
+            : throw new ArgumentOutOfRangeException(paramName, string.Format(CultureInfo.CurrentCulture, Messages.ArgumentOutOfRangeException_NotInCollection, string.Join(", ", allowedRange)));
 
         /// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if the parameter not in the collection, otherwise the parameter is passed.</summary>
         /// <typeparam name="T">The type to guard; must be a structure.</typeparam>
@@ -128,15 +104,9 @@ namespace Qowaiv
         [DebuggerStepThrough]
         public static T NotIn<T>(T parameter, string paramName, params T[] forbiddenRange)
             where T : struct
-        {
-            if (forbiddenRange.Contains(parameter))
-            {
-                var forbidden = string.Join(", ", forbiddenRange);
-                throw new ArgumentOutOfRangeException(paramName, string.Format(CultureInfo.CurrentCulture, Messages.ArgumentOutOfRangeException_InCollection, forbidden));
-            }
-
-            return parameter;
-        }
+            => forbiddenRange.Contains(parameter)
+            ? throw new ArgumentOutOfRangeException(paramName, string.Format(CultureInfo.CurrentCulture, Messages.ArgumentOutOfRangeException_InCollection, string.Join(", ", forbiddenRange)))
+            : parameter;
 
         /// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if the parameter not in not a defined value of the enum, otherwise the parameter is passed.</summary>
         /// <typeparam name="T">The type to guard; must be a structure (enum).</typeparam>
@@ -150,14 +120,9 @@ namespace Qowaiv
         /// </remarks>
         public static T DefinedEnum<T>(T parameter, string paramName)
             where T : struct
-        {
-            if (Enum.IsDefined(typeof(T), parameter))
-            {
-                return parameter;
-            }
-
-            throw new ArgumentOutOfRangeException(paramName, string.Format(CultureInfo.CurrentCulture, Messages.ArgumentOutOfRangeException_DefinedEnum, parameter, typeof(T)));
-        }
+            => Enum.IsDefined(typeof(T), parameter)
+            ? parameter
+            : throw new ArgumentOutOfRangeException(paramName, string.Format(CultureInfo.CurrentCulture, Messages.ArgumentOutOfRangeException_DefinedEnum, parameter, typeof(T)));
 
         /// <summary>
         /// Guards that the parameter is an instance of T, otherwise throws an argument (null) exception.
@@ -171,18 +136,11 @@ namespace Qowaiv
         /// The guarded parameter.
         /// </returns>
         [DebuggerStepThrough]
-#pragma warning disable S4018 // Generic methods should provide type parameters, but here it provides casting.
-        public static T IsInstanceOf<T>(object parameter, string paramName)
-#pragma warning restore S4018 // Generic methods should provide type parameters
-        {
-            NotNull(parameter, paramName);
-            if (!(parameter is T))
-            {
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Messages.ArgumentException_NotAnInstanceOf, typeof(T)), paramName);
-            }
+        public static T IsInstanceOf<T>([ValidatedNotNull] object parameter, string paramName)
+            => NotNull(parameter, paramName) is T instance
+            ? instance
+            : throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Messages.ArgumentException_NotAnInstanceOf, typeof(T)), paramName);
 
-            return (T)parameter;
-        }
 
         /// <summary>Guards that the parameter is not null or an empty collection, otherwise throws an argument (null) exception.</summary>
         /// <typeparam name="T">The type to guard; must be an <see cref="ICollection" />.</typeparam>
@@ -192,17 +150,11 @@ namespace Qowaiv
         /// The guarded parameter.
         /// </returns>
         [DebuggerStepThrough]
-        public static T HasAny<T>([ValidatedNotNull]T parameter, string paramName)
+        public static T HasAny<T>([ValidatedNotNull] T parameter, string paramName)
             where T : class, ICollection
-        {
-            NotNull(parameter, paramName);
-            if (parameter.Count == 0)
-            {
-                throw new ArgumentException(Messages.ArgumentException_EmptyCollection, paramName);
-            }
-
-            return parameter;
-        }
+            => NotNull(parameter, paramName).Count == 0
+            ? throw new ArgumentException(Messages.ArgumentException_EmptyCollection, paramName)
+            : parameter;
 
         /// <summary>Guards that the parameter is not null or an empty enumerable, otherwise throws an argument (null) exception.</summary>
         /// <typeparam name="T">The type to guard; must be an <see cref="IEnumerable" />.</typeparam>
@@ -212,16 +164,10 @@ namespace Qowaiv
         /// The guarded parameter.
         /// </returns>
         [DebuggerStepThrough]
-        public static IEnumerable<T> HasAny<T>([ValidatedNotNull]IEnumerable<T> parameter, string paramName)
-        {
-            NotNull(parameter, paramName);
-            if (!parameter.Any())
-            {
-                throw new ArgumentException(Messages.ArgumentException_EmptyCollection, paramName);
-            }
-
-            return parameter;
-        }
+        public static IEnumerable<T> HasAny<T>([ValidatedNotNull] IEnumerable<T> parameter, string paramName)
+            => NotNull(parameter, paramName).Any()
+            ? parameter
+            : throw new ArgumentException(Messages.ArgumentException_EmptyCollection, paramName);
 
         /// <summary>Guards that the parameter is not null or an empty string, otherwise throws an argument (null) exception.</summary>
         /// <param name="parameter">The parameter to guard.</param>
@@ -230,16 +176,10 @@ namespace Qowaiv
         /// The guarded parameter.
         /// </returns>
         [DebuggerStepThrough]
-        public static string NotNullOrEmpty([ValidatedNotNull]string parameter, string paramName)
-        {
-            NotNull(parameter, paramName);
-            if (parameter == string.Empty)
-            {
-                throw new ArgumentException(Messages.ArgumentException_StringEmpty, paramName);
-            }
-
-            return parameter;
-        }
+        public static string NotNullOrEmpty([ValidatedNotNull] string parameter, string paramName)
+            => NotNull(parameter, paramName) == string.Empty
+            ? throw new ArgumentException(Messages.ArgumentException_StringEmpty, paramName)
+            : parameter;
 
         /// <summary>Guards that the parameter is not an empty <see cref="Guid"/>, otherwise throws an argument exception.</summary>
         /// <param name="parameter">The parameter to guard.</param>
@@ -248,7 +188,8 @@ namespace Qowaiv
         /// The guarded parameter.
         /// </returns>
         [DebuggerStepThrough]
-        public static Guid NotEmpty(Guid? parameter, string paramName) => NotEmpty(HasValue(parameter, paramName), paramName);
+        public static Guid NotEmpty(Guid? parameter, string paramName)
+            => NotEmpty(HasValue(parameter, paramName), paramName);
 
         /// <summary>Guards that the parameter is not an empty <see cref="Guid"/>, otherwise throws an argument exception.</summary>
         /// <param name="parameter">The parameter to guard.</param>
@@ -258,14 +199,9 @@ namespace Qowaiv
         /// </returns>
         [DebuggerStepThrough]
         public static Guid NotEmpty(Guid parameter, string paramName)
-        {
-            if (parameter == Guid.Empty)
-            {
-                throw new ArgumentException(Messages.ArgumentException_GuidEmpty, paramName);
-            }
-
-            return parameter;
-        }
+            => parameter == Guid.Empty
+            ? throw new ArgumentException(Messages.ArgumentException_GuidEmpty, paramName)
+            : parameter;
 
         /// <summary>Throws an ArgumentException if the parameter is not positive, otherwise the parameter is passed.</summary>
         /// <param name="parameter">The parameter to guard.</param>
@@ -274,7 +210,8 @@ namespace Qowaiv
         /// The guarded parameter.
         /// </returns>
         [DebuggerStepThrough]
-        public static int Positive(int? parameter, string paramName) => Positive(HasValue(parameter, paramName), paramName);
+        public static int Positive(int? parameter, string paramName)
+            => Positive(HasValue(parameter, paramName), paramName);
 
         /// <summary>Throws an ArgumentException if the parameter is not positive, otherwise the parameter is passed.</summary>
         /// <param name="parameter">The parameter to guard.</param>
@@ -284,14 +221,9 @@ namespace Qowaiv
         /// </returns>
         [DebuggerStepThrough]
         public static int Positive(int parameter, string paramName)
-        {
-            if (parameter <= 0)
-            {
-                throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_NotPositive);
-            }
-
-            return parameter;
-        }
+            => parameter <= 0
+            ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_NotPositive)
+            : parameter;
 
         /// <summary>Throws an ArgumentException if the parameter is not positive, otherwise the parameter is passed.</summary>
         /// <param name="parameter">The parameter to guard.</param>
@@ -310,14 +242,9 @@ namespace Qowaiv
         /// </returns>
         [DebuggerStepThrough]
         public static long Positive(long parameter, string paramName)
-        {
-            if (parameter <= 0)
-            {
-                throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_NotPositive);
-            }
-
-            return parameter;
-        }
+            => parameter <= 0
+            ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_NotPositive)
+            : parameter;
 
         /// <summary>Throws an ArgumentException if the parameter is not positive, otherwise the parameter is passed.</summary>
         /// <param name="parameter">The parameter to guard.</param>
@@ -326,7 +253,8 @@ namespace Qowaiv
         /// The guarded parameter.
         /// </returns>
         [DebuggerStepThrough]
-        public static double Positive(double? parameter, string paramName) => Positive(HasValue(parameter, paramName), paramName);
+        public static double Positive(double? parameter, string paramName)
+            => Positive(HasValue(parameter, paramName), paramName);
 
         /// <summary>Throws an ArgumentException if the parameter is not positive, otherwise the parameter is passed.</summary>
         /// <param name="parameter">The parameter to guard.</param>
@@ -336,14 +264,9 @@ namespace Qowaiv
         /// </returns>
         [DebuggerStepThrough]
         public static double Positive(double parameter, string paramName)
-        {
-            if (parameter <= 0)
-            {
-                throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_NotPositive);
-            }
-
-            return parameter;
-        }
+            => parameter <= 0
+            ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_NotPositive)
+            : parameter;
 
         /// <summary>Throws an ArgumentException if the parameter is not positive, otherwise the parameter is passed.</summary>
         /// <param name="parameter">The parameter to guard.</param>
@@ -352,7 +275,8 @@ namespace Qowaiv
         /// The guarded parameter.
         /// </returns>
         [DebuggerStepThrough]
-        public static decimal Positive(decimal? parameter, string paramName) => Positive(HasValue(parameter, paramName), paramName);
+        public static decimal Positive(decimal? parameter, string paramName)
+            => Positive(HasValue(parameter, paramName), paramName);
 
         /// <summary>Throws an ArgumentException if the parameter is not positive, otherwise the parameter is passed.</summary>
         /// <param name="parameter">The parameter to guard.</param>
@@ -362,14 +286,9 @@ namespace Qowaiv
         /// </returns>
         [DebuggerStepThrough]
         public static decimal Positive(decimal parameter, string paramName)
-        {
-            if (parameter <= 0)
-            {
-                throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_NotPositive);
-            }
-
-            return parameter;
-        }
+            => parameter <= 0
+            ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_NotPositive)
+            : parameter;
 
         /// <summary>Throws an ArgumentException if the parameter is not positive, otherwise the parameter is passed.</summary>
         /// <param name="parameter">The parameter to guard.</param>
@@ -378,7 +297,8 @@ namespace Qowaiv
         /// The guarded parameter.
         /// </returns>
         [DebuggerStepThrough]
-        public static TimeSpan Positive(TimeSpan? parameter, string paramName) => Positive(HasValue(parameter, paramName), paramName);
+        public static TimeSpan Positive(TimeSpan? parameter, string paramName)
+            => Positive(HasValue(parameter, paramName), paramName);
 
         /// <summary>Throws an ArgumentException if the parameter is not positive, otherwise the parameter is passed.</summary>
         /// <param name="parameter">The parameter to guard.</param>
@@ -388,14 +308,9 @@ namespace Qowaiv
         /// </returns>
         [DebuggerStepThrough]
         public static TimeSpan Positive(TimeSpan parameter, string paramName)
-        {
-            if (parameter <= TimeSpan.Zero)
-            {
-                throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_NotPositive);
-            }
-
-            return parameter;
-        }
+            => parameter <= TimeSpan.Zero
+            ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_NotPositive)
+            : parameter;
 
         /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
         /// <param name="parameter">The parameter to guard.</param>
@@ -404,7 +319,8 @@ namespace Qowaiv
         /// The guarded parameter.
         /// </returns>
         [DebuggerStepThrough]
-        public static int NotNegative(int? parameter, string paramName) => NotNegative(HasValue(parameter, paramName), paramName);
+        public static int NotNegative(int? parameter, string paramName)
+            => NotNegative(HasValue(parameter, paramName), paramName);
 
         /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
         /// <param name="parameter">The parameter to guard.</param>
@@ -414,14 +330,9 @@ namespace Qowaiv
         /// </returns>
         [DebuggerStepThrough]
         public static int NotNegative(int parameter, string paramName)
-        {
-            if (parameter < 0)
-            {
-                throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_Negative);
-            }
-
-            return parameter;
-        }
+            => parameter < 0
+            ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_Negative)
+            : parameter;
 
         /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
         /// <param name="parameter">The parameter to guard.</param>
@@ -430,7 +341,8 @@ namespace Qowaiv
         /// The guarded parameter.
         /// </returns>
         [DebuggerStepThrough]
-        public static long NotNegative(long? parameter, string paramName) => NotNegative(HasValue(parameter, paramName), paramName);
+        public static long NotNegative(long? parameter, string paramName)
+            => NotNegative(HasValue(parameter, paramName), paramName);
 
         /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
         /// <param name="parameter">The parameter to guard.</param>
@@ -440,14 +352,9 @@ namespace Qowaiv
         /// </returns>
         [DebuggerStepThrough]
         public static long NotNegative(long parameter, string paramName)
-        {
-            if (parameter < 0)
-            {
-                throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_Negative);
-            }
-
-            return parameter;
-        }
+            => parameter < 0
+            ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_Negative)
+            : parameter;
 
         /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
         /// <param name="parameter">The parameter to guard.</param>
@@ -456,7 +363,8 @@ namespace Qowaiv
         /// The guarded parameter.
         /// </returns>
         [DebuggerStepThrough]
-        public static double NotNegative(double? parameter, string paramName) => NotNegative(HasValue(parameter, paramName), paramName);
+        public static double NotNegative(double? parameter, string paramName)
+            => NotNegative(HasValue(parameter, paramName), paramName);
 
         /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
         /// <param name="parameter">The parameter to guard.</param>
@@ -466,14 +374,9 @@ namespace Qowaiv
         /// </returns>
         [DebuggerStepThrough]
         public static double NotNegative(double parameter, string paramName)
-        {
-            if (parameter < 0)
-            {
-                throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_Negative);
-            }
-
-            return parameter;
-        }
+            => parameter < 0
+            ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_Negative)
+            : parameter;
 
         /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
         /// <param name="parameter">The parameter to guard.</param>
@@ -482,7 +385,8 @@ namespace Qowaiv
         /// The guarded parameter.
         /// </returns>
         [DebuggerStepThrough]
-        public static decimal NotNegative(decimal? parameter, string paramName) => NotNegative(HasValue(parameter, paramName), paramName);
+        public static decimal NotNegative(decimal? parameter, string paramName)
+            => NotNegative(HasValue(parameter, paramName), paramName);
 
         /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
         /// <param name="parameter">The parameter to guard.</param>
@@ -492,14 +396,9 @@ namespace Qowaiv
         /// </returns>
         [DebuggerStepThrough]
         public static decimal NotNegative(decimal parameter, string paramName)
-        {
-            if (parameter < 0)
-            {
-                throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_Negative);
-            }
-
-            return parameter;
-        }
+            => parameter < 0
+            ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_Negative)
+            : parameter;
 
         /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
         /// <param name="parameter">The parameter to guard.</param>
@@ -508,7 +407,8 @@ namespace Qowaiv
         /// The guarded parameter.
         /// </returns>
         [DebuggerStepThrough]
-        public static TimeSpan NotNegative(TimeSpan? parameter, string paramName) => NotNegative(HasValue(parameter, paramName), paramName);
+        public static TimeSpan NotNegative(TimeSpan? parameter, string paramName)
+            => NotNegative(HasValue(parameter, paramName), paramName);
 
         /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
         /// <param name="parameter">The parameter to guard.</param>
@@ -518,46 +418,35 @@ namespace Qowaiv
         /// </returns>
         [DebuggerStepThrough]
         public static TimeSpan NotNegative(TimeSpan parameter, string paramName)
-        {
-            if (parameter < TimeSpan.Zero)
-            {
-                throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_Negative);
-            }
-
-            return parameter;
-        }
+            => parameter < TimeSpan.Zero
+            ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_Negative)
+            : parameter;
 
         /// <summary>Messages class to group the constants.</summary>
         private static class Messages
         {
-#pragma warning disable SA1310 // Field names should not contain underscore
-
             public const string ArgumentException_EmptyCollection = "Argument cannot be an empty collection.";
             public const string ArgumentException_GuidEmpty = "Argument cannot be an empty GUID.";
             public const string ArgumentException_IsDefaultValue = "Argument is the not initialized/default value.";
             public const string ArgumentException_NotAnInstanceOf = "Argument is not an instance of {0}.";
             public const string ArgumentException_NullableMustHaveValue = "Nullable argument must have a value.";
             public const string ArgumentException_StringEmpty = "Argument cannot be an empty string.";
-
             public const string ArgumentOutOfRangeException_InCollection = "Argument was in the collection of forbidden values. Forbidden are {0}.";
             public const string ArgumentOutOfRangeException_NotInCollection = "Argument was not in the collection of allowed values. Allowed are {0}.";
-
             public const string ArgumentOutOfRangeException_DefinedEnum = "Argument {0} is not a defined value of {1}.";
-
             public const string ArgumentOutOfRangeException_Negative = "Argument should not be negative.";
             public const string ArgumentOutOfRangeException_NotPositive = "Argument should be positive.";
-
-#pragma warning restore SA1310 // Field names should not contain underscore
         }
 
         /// <summary>Marks the NotNull argument as being validated for not being null, to satisfy the static code analysis.</summary>
         /// <remarks>
         /// Notice that it does not matter what this attribute does, as long as
         /// it is named ValidatedNotNullAttribute.
+        ///
+        /// It is marked as conditional, as does not add anything to have the attribute compiled.
         /// </remarks>
+        [Conditional("Analysis")]
         [AttributeUsage(AttributeTargets.Parameter)]
-        private sealed class ValidatedNotNullAttribute : Attribute
-        {
-        }
+        private sealed class ValidatedNotNullAttribute : Attribute { }
     }
 }

--- a/shared/TypeHelper.cs
+++ b/shared/TypeHelper.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Qowaiv.Internals
 {
@@ -32,5 +34,37 @@ namespace Qowaiv.Internals
         {
             return objectType.IsGenericType && objectType.GetGenericTypeDefinition() == typeof(Nullable<>);
         }
+
+        /// <summary>Gets the candidate types.</summary>
+        /// <param name="types">
+        /// The types to select from.
+        /// </param>
+        public static IEnumerable<Type> GetCandidateTypes(IEnumerable<Type> types)
+            => types.Where(IsSupported)
+            .Select(type => IsIdBehavior(type) ? CreateIdType(type) : type);
+
+        /// <summary>Returns true if the type implements <see cref="BehaviorType"/> and can be initiated.</summary>
+        /// <param name="type">
+        /// The type to test for.
+        /// </param>
+        public static bool IsIdBehavior(Type type)
+            => !type.IsAbstract
+            && type.GetInterfaces().Any(i => i.FullName == BehaviorType)
+            && type.GetConstructors().Any(ctor => !ctor.GetParameters().Any());
+
+        private static Type CreateIdType(Type behavior)
+        {
+            var type = Type.GetType(IdType);
+            return type?.MakeGenericType(behavior);
+        }
+
+        private static bool IsSupported(Type type)
+            => !type.IsAbstract
+            && !type.IsGenericType
+            && !type.ContainsGenericParameters
+            && !type.IsGenericTypeDefinition;
+
+        private const string IdType = "Qowaiv.Identifiers.Id`1, Qowaiv";
+        private const string BehaviorType = "Qowaiv.Identifiers.IIdentifierBehavior";
     }
 }

--- a/shared/TypeHelper.cs
+++ b/shared/TypeHelper.cs
@@ -11,29 +11,8 @@ namespace Qowaiv.Internals
         /// <param name="objectType">
         /// The type to test for.
         /// </param>
-        public static Type GetNotNullableType(Type objectType)
-        {
-            if (objectType is null)
-            {
-                return null;
-            }
-
-            if (IsNullable(objectType))
-            {
-                return objectType.GetGenericArguments()[0];
-            }
-
-            return objectType;
-        }
-
-        /// <summary>Returns true if the object is null-able, otherwise false.</summary>
-        /// <param name="objectType">
-        /// The type to test for.
-        /// </param>
-        public static bool IsNullable(Type objectType)
-        {
-            return objectType.IsGenericType && objectType.GetGenericTypeDefinition() == typeof(Nullable<>);
-        }
+        public static Type NotNullable(Type objectType)
+            => objectType is { } ? Nullable.GetUnderlyingType(objectType) ?? objectType : null;
 
         /// <summary>Gets the candidate types.</summary>
         /// <param name="types">

--- a/src/Qowaiv.Bson.MongoDB/Qowaiv.Bson.MongoDB.csproj
+++ b/src/Qowaiv.Bson.MongoDB/Qowaiv.Bson.MongoDB.csproj
@@ -25,4 +25,11 @@
     <PackageReference Include="MongoDB.Bson" Version="2.13.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="SonarAnalyzer.CSharp" Version="8.29.0.36737">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/src/Qowaiv.Bson.MongoDB/Qowaiv.Bson.MongoDB.csproj
+++ b/src/Qowaiv.Bson.MongoDB/Qowaiv.Bson.MongoDB.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Bson" Version="2.10.1" />
+    <PackageReference Include="MongoDB.Bson" Version="2.13.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Qowaiv.Bson.MongoDB/QowaivBsonConverter.TSvo.cs
+++ b/src/Qowaiv.Bson.MongoDB/QowaivBsonConverter.TSvo.cs
@@ -10,19 +10,15 @@ namespace Qowaiv.Bson.MongoDB
     /// </typeparam>
     public class QowaivBsonConverter<TSvo> : SerializerBase<TSvo>
     {
-        private readonly ConventionBasedSerializer<TSvo> serializer = new ConventionBasedSerializer<TSvo>();
+        private readonly ConventionBasedSerializer<TSvo> serializer = new();
 
         /// <inheritdoc/>
         public override TSvo Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
-        {
-            return serializer.Deserialize(context, args);
-        }
+            => serializer.Deserialize(context, args);
 
         /// <inheritdoc/>
         public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, TSvo value)
-        {
-            serializer.Serialize(context, args, value);
-        }
+            => serializer.Serialize(context, args, value);
 
         /// <summary>Returns true if <typeparamref name="TSvo"/> is supported.</summary>
         internal bool TypeIsSupported => serializer.TypeIsSupported;

--- a/src/Qowaiv.Bson.MongoDB/QowaivBsonConverter.cs
+++ b/src/Qowaiv.Bson.MongoDB/QowaivBsonConverter.cs
@@ -1,7 +1,6 @@
 ﻿using MongoDB.Bson.Serialization;
 using Qowaiv.Internals;
 using System;
-using System.Linq;
 using System.Reflection;
 
 namespace Qowaiv.Bson.MongoDB

--- a/src/Qowaiv.Bson.MongoDB/QowaivBsonConverter.cs
+++ b/src/Qowaiv.Bson.MongoDB/QowaivBsonConverter.cs
@@ -65,9 +65,7 @@ namespace Qowaiv.Bson.MongoDB
         private static bool TypeIsSupported(IBsonSerializer converter)
             => (bool)converter
             .GetType()
-            .GetProperty(
-                nameof(QowaivBsonConverter<object>.TypeIsSupported),
-                BindingFlags.Instance | BindingFlags.NonPublic)
+            .GetProperty(nameof(QowaivBsonConverter<object>.TypeIsSupported), NonPublicInstance)
             .GetValue(converter, Array.Empty<object>());
 
         /// <summary>Creates an instance of <see cref="QowaivBsonConverter{TSvo}"/> based on the specified type.</summary>
@@ -76,5 +74,7 @@ namespace Qowaiv.Bson.MongoDB
             var converterType = typeof(QowaivBsonConverter<>).MakeGenericType(type);
             return (IBsonSerializer)Activator.CreateInstance(converterType);
         }
+
+        private const BindingFlags NonPublicInstance = (BindingFlags)36;
     }
 }

--- a/src/Qowaiv.Bson.MongoDB/QowaivBsonConverter.cs
+++ b/src/Qowaiv.Bson.MongoDB/QowaivBsonConverter.cs
@@ -1,4 +1,5 @@
 ﻿using MongoDB.Bson.Serialization;
+using Qowaiv.Internals;
 using System;
 using System.Linq;
 using System.Reflection;
@@ -16,7 +17,7 @@ namespace Qowaiv.Bson.MongoDB
         {
             Guard.NotNull(assembly, nameof(assembly));
 
-            foreach (var type in assembly.GetExportedTypes().Where(Supported))
+            foreach (var type in TypeHelper.GetCandidateTypes(assembly.GetExportedTypes()))
             {
                 var converter = CreateConverter(type);
                 if (TypeIsSupported(converter))
@@ -84,11 +85,5 @@ namespace Qowaiv.Bson.MongoDB
             var converter = (IBsonSerializer)Activator.CreateInstance(converterType);
             return converter;
         }
-
-        /// <summary><see cref="BsonSerializer"/> only support non-generic types.</summary>
-        private static bool Supported(Type type)
-            => !type.IsGenericType
-            && !type.ContainsGenericParameters
-            && !type.IsGenericTypeDefinition;
     }
 }

--- a/src/Qowaiv.Bson.MongoDB/QowaivBsonConverter.cs
+++ b/src/Qowaiv.Bson.MongoDB/QowaivBsonConverter.cs
@@ -14,12 +14,9 @@ namespace Qowaiv.Bson.MongoDB
         /// </param>
         public static void RegisterAssembly(Assembly assembly)
         {
-            Guard.NotNull(assembly, nameof(assembly));
-
-            foreach (var type in TypeHelper.GetCandidateTypes(assembly.GetExportedTypes()))
+            foreach (var type in TypeHelper.GetCandidateTypes(Guard.NotNull(assembly, nameof(assembly)).GetExportedTypes()))
             {
-                var converter = CreateConverter(type);
-                if (TypeIsSupported(converter))
+                if (CreateConverter(type) is var converter && TypeIsSupported(converter))
                 {
                     BsonSerializer.RegisterSerializer(type, converter);
                 }
@@ -32,9 +29,7 @@ namespace Qowaiv.Bson.MongoDB
         /// </param>
         public static void RegisterTypes(params Type[] types)
         {
-            Guard.HasAny(types, nameof(types));
-
-            foreach (var type in types)
+            foreach (var type in Guard.HasAny(types, nameof(types)))
             {
                 RegisterType(type);
             }
@@ -64,13 +59,11 @@ namespace Qowaiv.Bson.MongoDB
 
         /// <summary>Guard that the converter actually supports conversion based on conventions.</summary>
         private static IBsonSerializer GuardType(IBsonSerializer converter)
-            => TypeIsSupported(converter)
-            ? converter
-            : throw new NotSupportedException();
+            => TypeIsSupported(converter) ? converter : throw new NotSupportedException();
 
         /// <summary>Returns true if a name based convention is supported.</summary>
         private static bool TypeIsSupported(IBsonSerializer converter)
-        => (bool)converter
+            => (bool)converter
             .GetType()
             .GetProperty(
                 nameof(QowaivBsonConverter<object>.TypeIsSupported),
@@ -81,8 +74,7 @@ namespace Qowaiv.Bson.MongoDB
         private static IBsonSerializer CreateConverter(Type type)
         {
             var converterType = typeof(QowaivBsonConverter<>).MakeGenericType(type);
-            var converter = (IBsonSerializer)Activator.CreateInstance(converterType);
-            return converter;
+            return (IBsonSerializer)Activator.CreateInstance(converterType);
         }
     }
 }

--- a/src/Qowaiv.Json.Newtonsoft/Qowaiv.Json.Newtonsoft.csproj
+++ b/src/Qowaiv.Json.Newtonsoft/Qowaiv.Json.Newtonsoft.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -16,6 +16,13 @@
     <Compile Include="..\..\shared\ConventionBasedSerializer.Serialization.cs" Link="Qowaiv.Internals\ConventionBasedSerializer.Serialization.cs" />
     <Compile Include="..\..\shared\TypeHelper.cs" Link="Qowaiv.Internals\TypeHelper.cs" />
     <Compile Include="..\..\shared\Guard.cs" Link="Guard.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="SonarAnalyzer.CSharp" Version="8.29.0.36737">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/Qowaiv.Json.Newtonsoft/QowaivJsonConverter.cs
+++ b/src/Qowaiv.Json.Newtonsoft/QowaivJsonConverter.cs
@@ -29,7 +29,7 @@ namespace Qowaiv.Json.Newtonsoft
         /// <inheritdoc />
         public override bool CanConvert(Type objectType)
         {
-            var type = TypeHelper.GetNotNullableType(objectType);
+            var type = TypeHelper.NotNullable(objectType);
             return type != null
                 && !type.IsPrimitive
                 && CreateConverter(type) != null;
@@ -53,7 +53,7 @@ namespace Qowaiv.Json.Newtonsoft
 
         private JsonConverter CreateConverter(Type objectType)
         {
-            var type = TypeHelper.GetNotNullableType(objectType);
+            var type = TypeHelper.NotNullable(objectType);
 
             if (notSupported.Contains(type))
             {

--- a/src/Qowaiv.Text.Json.Serialization/Qowaiv.Text.Json.Serialization.csproj
+++ b/src/Qowaiv.Text.Json.Serialization/Qowaiv.Text.Json.Serialization.csproj
@@ -13,4 +13,11 @@
     <Compile Include="..\..\shared\TypeHelper.cs" Link="Qowaiv.Internals\TypeHelper.cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="SonarAnalyzer.CSharp" Version="8.29.0.36737">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/src/Qowaiv.Text.Json.Serialization/QowaivJsonConverter.cs
+++ b/src/Qowaiv.Text.Json.Serialization/QowaivJsonConverter.cs
@@ -11,16 +11,14 @@ namespace Qowaiv.Text.Json.Serialization
     {
         /// <inheritdoc />
         public override bool CanConvert(Type typeToConvert)
-        {
-            return typeToConvert != null
-                && !TypeHelper.GetNotNullableType(typeToConvert).IsPrimitive
-                && CreateConverter(typeToConvert, null) != null;
-        }
+            => typeToConvert is { }
+            && !TypeHelper.NotNullable(typeToConvert).IsPrimitive
+            && CreateConverter(typeToConvert, null) is { };
 
         /// <inheritdoc />
         public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
         {
-            var type = TypeHelper.GetNotNullableType(typeToConvert);
+            var type = TypeHelper.NotNullable(typeToConvert);
 
             if (notSupported.Contains(type))
             {
@@ -52,8 +50,8 @@ namespace Qowaiv.Text.Json.Serialization
             return converter;
         }
 
-        private readonly object locker = new object();
-        private readonly Dictionary<Type, JsonConverter> converters = new Dictionary<Type, JsonConverter>();
-        private readonly HashSet<Type> notSupported = new HashSet<Type>();
+        private readonly object locker = new();
+        private readonly Dictionary<Type, JsonConverter> converters = new();
+        private readonly HashSet<Type> notSupported = new();
     }
 }

--- a/test/Qowaiv.Json.UnitTests/Qowaiv.Json.UnitTests.csproj
+++ b/test/Qowaiv.Json.UnitTests/Qowaiv.Json.UnitTests.csproj
@@ -3,19 +3,23 @@
   <Import Project="..\..\props\nopackage.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <Compile Include="..\..\shared\TypeHelper.cs" Link="Qowaiv.Internals\TypeHelper.cs" />
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <PackageReference Include="nunit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
-    <PackageReference Include="Qowaiv" Version="5.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Qowaiv" Version="5.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Qowaiv.Json.UnitTests/Qowaiv.Json.UnitTests.csproj
+++ b/test/Qowaiv.Json.UnitTests/Qowaiv.Json.UnitTests.csproj
@@ -29,4 +29,11 @@
     <ProjectReference Include="..\..\src\Qowaiv.Text.Json.Serialization\Qowaiv.Text.Json.Serialization.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="SonarAnalyzer.CSharp" Version="8.29.0.36737">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/test/Qowaiv.Json.UnitTests/Qowaiv.Json.UnitTests.csproj
+++ b/test/Qowaiv.Json.UnitTests/Qowaiv.Json.UnitTests.csproj
@@ -13,6 +13,7 @@
 
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.1.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Qowaiv.Json.UnitTests/TypeHelper_specs.cs
+++ b/test/Qowaiv.Json.UnitTests/TypeHelper_specs.cs
@@ -1,0 +1,65 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using Qowaiv;
+using Qowaiv.Identifiers;
+using Qowaiv.Internals;
+using System;
+using System.Collections.Generic;
+
+namespace TypeHelper_specs
+{
+    public class Is_no_IdBehavior
+    {
+        [Test]
+        public void Misses_interface() => TypeHelper.IsIdBehavior(typeof(object)).Should().BeFalse();
+
+        [Test]
+        public void No_empty_ctor() => TypeHelper.IsIdBehavior(typeof(BehaviorWithoutCtor)).Should().BeFalse();
+
+        [Test]
+        public void is_abstract() => TypeHelper.IsIdBehavior(typeof(AbstractBehavior)).Should().BeFalse();
+    }
+    
+    public class Is_IdBehavior
+    {
+        [Test]
+        public void With_interface_and_ctor() => TypeHelper.IsIdBehavior(typeof(SomeBehavior)).Should().BeTrue();
+
+    }
+
+    public class CandidateTypes
+    {
+        [Test]
+        public void GetCandidateTypes_skips_unsupported_converts_ids()
+        {
+            var types = new[]
+            { 
+                typeof(object), 
+                typeof(Uuid),
+                typeof(EmailAddress),
+                typeof(SomeBehavior),
+                typeof(AbstractBehavior),
+                typeof(List<int>),
+                typeof(List<>) 
+            };
+
+            TypeHelper.GetCandidateTypes(types)
+                .Should().BeEquivalentTo(new[]
+                {
+                    typeof(object),
+                    typeof(Uuid),
+                    typeof(EmailAddress),
+                    typeof(Id<SomeBehavior>),
+                });
+        }
+    }
+
+    public sealed class SomeBehavior : UuidBehavior { }
+
+    public sealed class BehaviorWithoutCtor : UuidBehavior
+    {
+        private BehaviorWithoutCtor() { }
+    }
+
+    public abstract class AbstractBehavior : UuidBehavior { }
+}

--- a/test/Qowaiv.Json.UnitTests/TypeHelper_specs.cs
+++ b/test/Qowaiv.Json.UnitTests/TypeHelper_specs.cs
@@ -3,7 +3,6 @@ using NUnit.Framework;
 using Qowaiv;
 using Qowaiv.Identifiers;
 using Qowaiv.Internals;
-using System;
 using System.Collections.Generic;
 
 namespace TypeHelper_specs


### PR DESCRIPTION
So that defined `IIdentifierBehavior` classes are registered as `Id<TBehavior`.