### PR TITLE
BSON Register types supports Qowaiv.Customization.Svo<SvoBehavior>

### DIFF
--- a/props/common.props
+++ b/props/common.props
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.40.0.48530">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.47.0.55603">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Qowaiv.Bson.MongoDB/Qowaiv.Bson.MongoDB.csproj
+++ b/src/Qowaiv.Bson.MongoDB/Qowaiv.Bson.MongoDB.csproj
@@ -7,8 +7,12 @@
     <Version>4.2.0</Version>
     <PackageIcon>package-icon-bson.png</PackageIcon>
     <PackageReleaseNotes>
+v4.2.0
+- Registered SvoBehavior as Svo&lt;TSvoBehavior&gt;. #13
+- Multi-targeted to netstandard2.0, .NET 5.0, and .NET 6.0. #12
+
 v4.1.0
-- Registered IIdentifierBehavior as Id&lt;TBehavior&gt; #7
+- Registered IIdentifierBehavior as Id&lt;TBehavior&gt;. #7
 
 v4.0.2
 - Only register exported.

--- a/src/Qowaiv.Json.Newtonsoft/Qowaiv.Json.Newtonsoft.csproj
+++ b/src/Qowaiv.Json.Newtonsoft/Qowaiv.Json.Newtonsoft.csproj
@@ -5,6 +5,10 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <Version>4.2.0</Version>
+    <PackageReleaseNotes>
+v4.2.0
+- Multi-targeted to netstandard2.0, .NET 5.0, and .NET 6.0. #12
+    </PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Qowaiv.Text.Json.Serialization/Qowaiv.Text.Json.Serialization.csproj
+++ b/src/Qowaiv.Text.Json.Serialization/Qowaiv.Text.Json.Serialization.csproj
@@ -5,6 +5,10 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Version>4.2.0</Version>
+    <PackageReleaseNotes>
+v4.2.0
+- Multi-targeted to netstandard2.0, .NET 5.0, and .NET 6.0. #12
+    </PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Qowaiv.Json.UnitTests/BsonMongoDBSerializeTest.cs
+++ b/test/Qowaiv.Json.UnitTests/BsonMongoDBSerializeTest.cs
@@ -15,7 +15,7 @@ public class BsonMongoDBSerializeTest : JsonSerializeTestBase<FormatException>
         QowaivBsonConverter.RegisterType<SvoWithFromJson>();
         QowaivBsonConverter.RegisterType<SvoWithFromJsonClass>();
         QowaivBsonConverter.RegisterType<SvoWithFromJsonStringOnly>();
-        QowaivBsonConverter.RegisterType<Identifiers.Id<ForGeneric>>();
+        QowaivBsonConverter.RegisterType<Qowaiv.Identifiers.Id<ForGeneric>>();
     }
 
     [Test, Ignore("For BSON a Date() is generated, that is default behaviour we don't want to interfere with.")]

--- a/test/Qowaiv.Json.UnitTests/Models/ForGeneric.cs
+++ b/test/Qowaiv.Json.UnitTests/Models/ForGeneric.cs
@@ -1,3 +1,3 @@
 ﻿namespace Qowaiv.Json.UnitTests.Models;
 
-public sealed class ForGeneric : Identifiers.Int32IdBehavior { }
+public sealed class ForGeneric : Qowaiv.Identifiers.Int32IdBehavior { }

--- a/test/Qowaiv.Json.UnitTests/Qowaiv.Json.UnitTests.csproj
+++ b/test/Qowaiv.Json.UnitTests/Qowaiv.Json.UnitTests.csproj
@@ -27,7 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Qowaiv" Version="6.1.0" />
+    <PackageReference Include="Qowaiv" Version="6.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Qowaiv.Json.UnitTests/Qowaiv.Json.UnitTests.csproj
+++ b/test/Qowaiv.Json.UnitTests/Qowaiv.Json.UnitTests.csproj
@@ -12,18 +12,18 @@
 
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+    <PackageReference Include="coverlet.msbuild" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.6.0" />
+    <PackageReference Include="FluentAssertions" Version="6.8.0" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.17.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Qowaiv.Json.UnitTests/TypeHelper_specs.cs
+++ b/test/Qowaiv.Json.UnitTests/TypeHelper_specs.cs
@@ -1,29 +1,48 @@
 ﻿using FluentAssertions;
 using NUnit.Framework;
 using Qowaiv;
+using Qowaiv.Customization;
 using Qowaiv.Identifiers;
 using Qowaiv.Internals;
 using System.Collections.Generic;
 
 namespace TypeHelper_specs;
 
-public class Is_no_IdBehavior
+public class Is_no_ID_Behavior
 {
     [Test]
-    public void Misses_interface() => TypeHelper.IsIdBehavior(typeof(object)).Should().BeFalse();
+    public void Misses_interface() => TypeHelper.IdBehavior(typeof(object)).Should().BeNull();
 
     [Test]
-    public void No_empty_ctor() => TypeHelper.IsIdBehavior(typeof(BehaviorWithoutCtor)).Should().BeFalse();
-
-    [Test]
-    public void is_abstract() => TypeHelper.IsIdBehavior(typeof(AbstractBehavior)).Should().BeFalse();
+    public void No_empty_ctor() => TypeHelper.IdBehavior(typeof(BehaviorWithoutCtor)).Should().BeNull();
 }
 
-public class Is_IdBehavior
+public class Is_no_SVO_Behavior
 {
     [Test]
-    public void With_interface_and_ctor() => TypeHelper.IsIdBehavior(typeof(SomeBehavior)).Should().BeTrue();
+    public void Misses_base_type() => TypeHelper.SvoBehavior(typeof(object)).Should().BeNull();
 
+    [Test]
+    public void No_empty_ctor() => TypeHelper.SvoBehavior(typeof(SvoBehaviorWithoutCtor)).Should().BeNull();
+}
+
+
+public class Is_ID_Behavior
+{
+    [Test]
+    public void With_interface_and_ctor() 
+        => TypeHelper.IdBehavior(typeof(SomeBehavior)).Should().Be(typeof(Id<SomeBehavior>));
+}
+
+public class Is_SVO_dBehavior
+{
+    [Test]
+    public void With_base_type_and_ctor()
+        => TypeHelper.SvoBehavior(typeof(SomeSvoBehavior)).Should().Be(typeof(Svo<SomeSvoBehavior>));
+
+    [Test]
+    public void With_ancestor_type_and_ctor()
+        => TypeHelper.SvoBehavior(typeof(SomeInheritedSvoBehavior)).Should().Be(typeof(Svo<SomeInheritedSvoBehavior>));
 }
 
 public class CandidateTypes
@@ -37,7 +56,7 @@ public class CandidateTypes
             typeof(Uuid),
             typeof(EmailAddress),
             typeof(SomeBehavior),
-            typeof(AbstractBehavior),
+            typeof(SomeSvoBehavior),
             typeof(List<int>),
             typeof(List<>) 
         };
@@ -49,17 +68,26 @@ public class CandidateTypes
                 typeof(Uuid),
                 typeof(EmailAddress),
                 typeof(Id<SomeBehavior>),
+                typeof(Svo<SomeSvoBehavior>),
             });
     }
 }
 
 public sealed class SomeBehavior : UuidBehavior { }
 
+public class SomeSvoBehavior : SvoBehavior { }
+
+public sealed class SomeInheritedSvoBehavior : SomeSvoBehavior { }
+
 #pragma warning disable S3453 // Classes should not have only "private" constructors
 // The behavior we want to test.
+
 public sealed class BehaviorWithoutCtor : UuidBehavior
 {
     private BehaviorWithoutCtor() { }
 }
 
-public abstract class AbstractBehavior : UuidBehavior { }
+public sealed class SvoBehaviorWithoutCtor : SvoBehavior
+{
+    private SvoBehaviorWithoutCtor() { }
+}

--- a/test/Qowaiv.Json.UnitTests/TypeHelper_specs.cs
+++ b/test/Qowaiv.Json.UnitTests/TypeHelper_specs.cs
@@ -14,7 +14,7 @@ public class Is_no_ID_Behavior
     public void Misses_interface() => TypeHelper.IdBehavior(typeof(object)).Should().BeNull();
 
     [Test]
-    public void No_empty_ctor() => TypeHelper.IdBehavior(typeof(BehaviorWithoutCtor)).Should().BeNull();
+    public void No_empty_ctor() => TypeHelper.IdBehavior(typeof(IdBehaviorWithoutCtor)).Should().BeNull();
 }
 
 public class Is_no_SVO_Behavior
@@ -31,7 +31,7 @@ public class Is_ID_Behavior
 {
     [Test]
     public void With_interface_and_ctor() 
-        => TypeHelper.IdBehavior(typeof(SomeBehavior)).Should().Be(typeof(Id<SomeBehavior>));
+        => TypeHelper.IdBehavior(typeof(SomeIdBehavior)).Should().Be(typeof(Id<SomeIdBehavior>));
 }
 
 public class Is_SVO_dBehavior
@@ -55,8 +55,10 @@ public class CandidateTypes
             typeof(object), 
             typeof(Uuid),
             typeof(EmailAddress),
-            typeof(SomeBehavior),
+            typeof(SomeIdBehavior),
             typeof(SomeSvoBehavior),
+            typeof(AbstractIdBehavior),
+            typeof(AbstractSvoBehavior),
             typeof(List<int>),
             typeof(List<>) 
         };
@@ -67,13 +69,13 @@ public class CandidateTypes
                 typeof(object),
                 typeof(Uuid),
                 typeof(EmailAddress),
-                typeof(Id<SomeBehavior>),
+                typeof(Id<SomeIdBehavior>),
                 typeof(Svo<SomeSvoBehavior>),
             });
     }
 }
 
-public sealed class SomeBehavior : UuidBehavior { }
+public sealed class SomeIdBehavior : UuidBehavior { }
 
 public class SomeSvoBehavior : SvoBehavior { }
 
@@ -82,12 +84,15 @@ public sealed class SomeInheritedSvoBehavior : SomeSvoBehavior { }
 #pragma warning disable S3453 // Classes should not have only "private" constructors
 // The behavior we want to test.
 
-public sealed class BehaviorWithoutCtor : UuidBehavior
+public sealed class IdBehaviorWithoutCtor : UuidBehavior
 {
-    private BehaviorWithoutCtor() { }
+    private IdBehaviorWithoutCtor() { }
 }
 
 public sealed class SvoBehaviorWithoutCtor : SvoBehavior
 {
     private SvoBehaviorWithoutCtor() { }
 }
+
+public abstract class AbstractIdBehavior : GuidBehavior { }
+public abstract class AbstractSvoBehavior : SvoBehavior { }


### PR DESCRIPTION
As reported in #12 , assemblies containing non-abstract inherited types of `Qowaiv.Customization.SvoBehavior`, should be registered.